### PR TITLE
heroku local command fails with reference to an old project name

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: target/universal/stage/bin/play-getting-started -Dhttp.port=${PORT}
-console: target/universal/stage/bin/play-getting-started -main scala.tools.nsc.MainGenericRunner -usejavacp
+web: target/universal/stage/bin/scala-getting-started -Dhttp.port=${PORT}
+console: target/universal/stage/bin/scala-getting-started -main scala.tools.nsc.MainGenericRunner -usejavacp

--- a/Procfile.windows
+++ b/Procfile.windows
@@ -1,1 +1,1 @@
-web: target\universal\stage\bin\play-getting-started.bat
+web: target\universal\stage\bin\scala-getting-started.bat

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# scala/play-getting-started
+# scala/scala-getting-started
 
 A barebones Scala app (using the Play framework), which can easily be deployed to Heroku.  
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := """play-getting-started"""
+name := """scala-getting-started"""
 
 version := "1.0-SNAPSHOT"
 


### PR DESCRIPTION
When following the Scala getting started on the heroku website it references how to start a local instance of the web app with

```
sbt compile stage
heroku local
```

However, since the Procfile referenced the wrong location of the staged application. Switching to the new name allows the `heroku local` command to successfully work.

I simply did a replace all in the project, however you guys might not want that.