### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
-updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "monthly"
+# Our 3PP enforcement tooling requires that each repo has a Dependabot config,
+# however, Dependabot doesn't yet support sbt, so this is empty for now. See:
+# https://github.com/dependabot/dependabot-core/issues/352
+updates: []


### PR DESCRIPTION
Since all components in the Heroku Component Inventory are required to have one.

I've copied the config already used by `java-getting-started`:
https://github.com/heroku/java-getting-started/blob/main/.github/dependabot.yml

GUS-W-17981048.