### PR TITLE
Disable Jansi

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -12,7 +12,6 @@
   </appender>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <withJansi>true</withJansi>
     <encoder>
       <charset>UTF-8</charset>
       <pattern>


### PR DESCRIPTION
Disables Jansi in the Logback configuration by removing the `<withJansi>true</withJansi>` setting from the console appender in `conf/logback.xml`.

While adding the Jansi dependency would also resolve this, keeping this getting started application minimal is preferred over adding another dependency just for colored console output.

GUS-W-20956982