### PR TITLE
Use Play 3.x and OpenJDK 25

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -15,7 +15,7 @@ class Application @Inject()(val controllerComponents: ControllerComponents, val 
   def db(): Action[AnyContent] = Action { implicit request: Request[AnyContent] =>
     // In this getting started app, we don't use a custom execution context to keep the code and configuration simple.
     // For real-world apps, consult the Play documentation on how to configure custom contexts and how to use them:
-    // https://www.playframework.com/documentation/2.8.19/AccessingAnSQLDatabase#Using-a-CustomExecutionContext
+    // https://www.playframework.com/documentation/latest/AccessingAnSQLDatabase#Using-a-CustomExecutionContext
     database.withConnection { connection =>
       val statement = connection.createStatement()
       statement.executeUpdate("CREATE TABLE IF NOT EXISTS ticks (tick timestamp)")

--- a/build.sbt
+++ b/build.sbt
@@ -9,15 +9,5 @@ scalaVersion := "2.13.18"
 
 libraryDependencies += guice
 libraryDependencies += jdbc
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test
-libraryDependencies ++= Seq(
-  "com.google.inject"            % "guice"                % "5.1.0",
-  "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
-  "org.postgresql" % "postgresql" % "42.6.0"
-)
+libraryDependencies += "org.postgresql" % "postgresql" % "42.7.10"
 
-// Adds additional packages into Twirl
-//TwirlKeys.templateImports += "com.heroku.controllers._"
-
-// Adds additional packages into conf/routes
-// play.sbt.routes.RoutesKeys.routesImport += "com.heroku.binders._"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,14 +3,14 @@
 # Allows all hosts to be valid hosts for requests to this app. This is necessary since this getting started guide
 # makes users deploy their own app of which we don't know the hostname in advance. For production apps, set this 
 # to the correct host of your application.
-# More info: https://www.playframework.com/documentation/2.8.x/AllowedHostsFilter
+# More info: https://www.playframework.com/documentation/latest/AllowedHostsFilter
 play.filters.hosts {
   allowed = ["."]
 }
 
 # Sets the secret key if the APPLICATION_SECRET environment variable isn't set. It is recommended to set the
 # application secret for production apps via heroku config:set on the command line.
-# More info: https://www.playframework.com/documentation/2.8.x/ApplicationSecret
+# More info: https://www.playframework.com/documentation/latest/ApplicationSecret
 play.http.secret.key = "YWRmNTNmZDYtMTE5NS00MTc1LWI4YmMtMGU3ZmY2NTE1NDI0Cg=="
 play.http.secret.key = ${?APPLICATION_SECRET}
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -6,7 +6,7 @@
     <encoder>
       <charset>UTF-8</charset>
       <pattern>
-        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n
+        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -15,7 +15,7 @@
     <encoder>
       <charset>UTF-8</charset>
       <pattern>
-        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n
+        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n
       </pattern>
     </encoder>
   </appender>

--- a/system.properties
+++ b/system.properties
@@ -1,2 +1,2 @@
 # https://devcenter.heroku.com/articles/java-support#specifying-a-java-version
-java.runtime.version=17
+java.runtime.version=25


### PR DESCRIPTION
Updates the sample app to use Play 3.x (from Play 2.8.x) with OpenJDK `25` (from `17`).

Removes unnecessary dependency overrides from `build.sbt` that are no longer needed with Play 3.x, updates documentation URLs from versioned to `/latest`, and replaces Akka references with Pekko (Play 3.x switched from Akka to Pekko).

GUS-W-21037844