### PR TITLE
Fix GUSINFO metadata in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Note: Delete this file if you are copying the code in this repository into your own project.
 
 #ECCN:Open Source
-#GUSINFO:Languages,Heroku JVM Platform
+#GUSINFO:Heroku - Languages,Heroku JVM Platform
 * @heroku/languages

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 /.project
 /.settings
 /RUNNING_PID
+.DS_Store


### PR DESCRIPTION
Since the Languages team was renamed to `Heroku - Languages` in GUS some time ago.

GUS-W-21708465.